### PR TITLE
Adds the possibility to include metadata when loading the client

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,8 @@ MediaRendererClient.prototype.load = function(url, options, callback) {
 
   var contentType = options.contentType || 'video/mpeg'; // Default to something generic
 
+  var metadata = options.metadata || null;
+
   var params = {
     RemoteProtocolInfo: 'http-get:*:' + contentType + ':*',
     PeerConnectionManager: null,
@@ -62,7 +64,7 @@ MediaRendererClient.prototype.load = function(url, options, callback) {
     var params = {
       InstanceID: self.instanceId,
       CurrentURI: url,
-      CurrentURIMetaData: null
+      CurrentURIMetaData: metadata
     };
 
     self.callAction('AVTransport', 'SetAVTransportURI', params, function(err) {


### PR DESCRIPTION
When loading the renderer client, it would be great to have the option to include a metadata to send to the AVTransport. The metadata could include several information, like title, cover image, description, and even subtitle.

I simply included a new option value called "metadata", that could be passed in the options object when calling the load function.