### PR TITLE
A little hack from the Popcorntime code to make streaming work on Philips TVs

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,6 +276,9 @@ function buildMetadata(metadata) {
     //res.text = metadata.subtitlesUrl;
 
   }
+  
+  var res = et.SubElement(item, 'res');
+  res.set('protocolInfo', 'http-get:*:video/mpeg:*');
 
   var doc = new et.ElementTree(didl);
   var xml = doc.write({ xml_declaration: false });


### PR DESCRIPTION
Without this, the DLNA user inteface never kicks in on my philips TV.