### PR TITLE
Fixed MediaRendererClient.prototype.getPosition is now working on XBOX ONE

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,8 @@ MediaRendererClient.prototype.getSupportedProtocols = function(callback) {
 MediaRendererClient.prototype.getPosition = function(callback) {
   this.callAction('AVTransport', 'GetPositionInfo', { InstanceID: this.instanceId }, function(err, result) {
     if(err) return callback(err);
-    callback(null, parseTime(result.AbsTime));
+    if (result.AbsTime != 'NOT_IMPLEMENTED') return callback(null, parseTime(result.AbsTime));
+    callback(null, parseTime(result.RelTime));
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upnp-mediarenderer-client",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "An UPnP/DLNA MediaRenderer client",
   "author": "thibauts",
   "license": "MIT",


### PR DESCRIPTION
MediaRendererClient.prototype.getPosition is now working on XBOX ONE